### PR TITLE
Feature: #70 D-Day 컴포넌트 구현

### DIFF
--- a/DanDan/DanDan/Sources/Views/Components/Map/DDayView.swift
+++ b/DanDan/DanDan/Sources/Views/Components/Map/DDayView.swift
@@ -1,0 +1,60 @@
+//
+//  DDayView.swift
+//  DanDan
+//
+//  Created by soyeonsoo on 11/3/25.
+//
+
+import SwiftUI
+
+struct DDayView: View {
+    let period: ConquestPeriod
+    var now: () -> Date = { Date() }   // 테스트/프리뷰 주입 용
+    
+    // 게임 종료까지 남은 일수 계산
+    private var daysRemaining: Int {
+        let cal = Calendar.current
+        let todayStartOfDay = cal.startOfDay(for: now())
+        let endOfWeek   = cal.startOfDay(for: period.endDate)
+        return max(0, cal.dateComponents([.day], from: todayStartOfDay, to: endOfWeek).day ?? 0)
+    }
+    
+    private var ddayText: String {
+        daysRemaining == 0 ? "D-Day" : "D-\(daysRemaining)"
+    }
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("경기 종료까지")
+                .font(.PR.body4)
+                .foregroundStyle(.gray1)
+            
+            Text(ddayText)
+                .font(.PR.title2)
+                .foregroundStyle(.steelBlack)
+        }
+        .padding(.vertical, 20)
+        .padding(.horizontal, 22)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .stroke(.white.opacity(0.6), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.1), radius: 14, x: 0, y: 8)
+        )
+        .fixedSize()
+    }
+}
+
+//#Preview {
+//    let start = Calendar.current.date(byAdding: .day, value: -4, to: Date())!
+//    let period = ConquestPeriod(startDate: start, durationInDays: 7)
+//        
+//    DDayView(period: period)
+//        .padding(.top, 8)
+//        .padding(.leading, 20)
+//        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+//    
+//}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #70 

---

## 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
<!-- 
예시:
- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시
-->

- 맵뷰 좌상단에 올라갈 D-Day 컴포넌트를 만들었습니다.
  
---

## 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="146" height="114" alt="스크린샷 2025-11-03 20 59 03" src="https://github.com/user-attachments/assets/3bfbbe4e-f14a-4552-aec2-adf4f1af4e7a" />

---

## 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->
<!--
예시:
- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다
-->

- 경기 종료까지 며칠 남았는지 계산하는 로직이 들어있어요. MapViewModel로 가야할 것 같은데 세나가 해당 파일에서 작업 중일테니 우선 컴포넌트 파일 안에 두겠습니다. 다른 좋은 방법을 아신다면 알려주세욤
