### PR TITLE
Design: RankingCard UI 컴포넌트 (배지 merge 후 reopen)

### DIFF
--- a/DanDan/DanDan/Sources/Views/Ranking/SubViews/PersonalRank/RankingList/Component/RankingCard.swift
+++ b/DanDan/DanDan/Sources/Views/Ranking/SubViews/PersonalRank/RankingList/Component/RankingCard.swift
@@ -1,0 +1,74 @@
+//
+//  RankingCard.swift
+//  DanDan
+//
+//  Created by Jay on 11/4/25.
+//
+
+import SwiftUI
+
+struct RankingCard: View {
+    private let image: Image
+    private let name: String
+    private let color: Color
+    private let score: Int
+    
+    init(
+        name: String,
+        score: Int,
+        image: Image = Image("testImage"),
+        color: Color = .gray3
+    ) {
+        self.name = name
+        self.score = score
+        self.image = image
+        self.color = color
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                color
+
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 56, height: 56)
+                    .clipShape(Circle())
+                    .padding(.vertical, 10)
+                    .shadow(color: .black.opacity(0.25), radius: 2, x: 0, y: 2)
+            }
+
+            VStack {
+                Text(name)
+                    .font(.PR.body2)
+                    .foregroundStyle(.steelBlack)
+
+                Text("\(score)점")
+                    .font(.PR.body3)
+                    .foregroundStyle(.gray2)
+            }
+            .padding(.vertical, 10)
+        }
+        .frame(width: 110, height: 135)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.25), radius: 2, x: 0, y: 2)
+    }
+}
+
+#Preview {
+    VStack(spacing: 12) {
+        RankingCard(
+            name: "황세연",
+            score: 9,
+            image: Image("testImage"),
+            color: .subA50
+        )
+
+        RankingCard(
+            name: "김철수",
+            score: 12
+        )
+    }
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #106 

---

## 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
<!-- 
예시:
- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시
-->

- 랭킹 카드 UI 컴포넌트 구현
- 프로퍼티를 private로 선언하여 캡슐화 강화
- image, color 기본값 추가
  
---

## 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="175" height="318" alt="image" src="https://github.com/user-attachments/assets/0559527a-bc92-4608-8061-a836266a09f9" />


---

## 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->
<!-- 
예시:
- [ ] UI 정상 동작 확인
- [ ] iPhone 16, iOS 18 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)
-->


---

## 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->
<!--
예시:
- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다
-->

- 앞으로 컴포넌트 제작시, 프로퍼티를 통일되게 private로 선언해 내부 응집도를 높이고자 합니다-! 
  
---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
<!--
예시:
- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
-->

