### PR TITLE
Chore: 랭킹뷰 리스트에 학교 이름 넣기

### DIFF
--- a/DanDan/DanDan/Sources/Views/Ranking/PersonalRank/RankingList/Component/RankingItemView.swift
+++ b/DanDan/DanDan/Sources/Views/Ranking/PersonalRank/RankingList/Component/RankingItemView.swift
@@ -44,10 +44,10 @@ struct RankingItemView: View {
             Spacer()
             
 //            // TODO: UT 후 수정
-//            Text(mappedTeamName)
-//                .padding(.trailing, 5)
-//                .font(.PR.body4)
-//                .foregroundStyle(.gray3)
+            Text(mappedTeamName)
+                .padding(.trailing, 5)
+                .font(.PR.body4)
+                .foregroundStyle(.gray3)
 
             Text("\(rank.userWeekScore)")
                 .padding(.trailing, 24)


### PR DESCRIPTION

## 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
<!-- 
예시:
- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시
-->

- 랭킹뷰 리스트 아이템에도 학교 이름을 넣었어요.
- 카드에는 안 넣었어요.
  
---

## 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-12 at 17 33 50" src="https://github.com/user-attachments/assets/8349b948-af5b-4ac0-89dd-54db2cc83e32" />

