### PR TITLE
Design: ProfileSetupView 멘트, 아이콘 변경

### DIFF
--- a/DanDan/DanDan/Sources/Views/Auth /ProfileSetup/ProfileSetupView.swift
+++ b/DanDan/DanDan/Sources/Views/Auth /ProfileSetup/ProfileSetupView.swift
@@ -18,7 +18,7 @@ struct ProfileSetupView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             
-            TitleSectionView(title: "회원가입하기", description: "나만의 닉네임과 프로필을 설정해주세요.")
+            TitleSectionView(title: "회원가입", description: "프로필과 닉네임을 설정해주세요.")
             
             ProfileSetupSectionView(
                 profileImage: $viewModel.profileImage,
@@ -37,9 +37,9 @@ struct ProfileSetupView: View {
                 },
                 isEnabled: !viewModel.nickname.trimmingCharacters(in: .whitespaces).isEmpty && !isNicknameTooLong,
                 horizontalPadding: 20,
-                verticalPadding: 8,
+                verticalPadding: 0,
             )
-            .padding(.bottom, 24)
+            .padding(.bottom, 20)
         }
         .padding(.top, 68)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/DanDan/DanDan/Sources/Views/Auth /ProfileSetup/SubViews/ProfileSetupSection /Component/AvatarEditButton.swift
+++ b/DanDan/DanDan/Sources/Views/Auth /ProfileSetup/SubViews/ProfileSetupSection /Component/AvatarEditButton.swift
@@ -44,8 +44,8 @@ struct AvatarEditButton: View {
                         }
                     )
 
-                Image(systemName: "pencil")
-                    .font(.system(size: 20, weight: .bold))
+                Image(systemName: "camera.on.rectangle.fill")
+                    .font(.system(size: 16, weight: .bold))
                     .foregroundStyle(.white)
                     .offset(y: overlayHeight)
             }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #257 

---

## 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
<!-- 
예시:
- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시
-->

- 데모로 둔 멘트 변경

- 아이콘 변경
프로필 수정 페이지에서는 계속해서 기존 pencil.pill 사용!, 등록하는 부분에서 수정하는 아이콘이 사용되어서 이 부분만 수정했어요.

- 피그마 규격에 맞게 패딩값 조절
기존 PrimaryButton의 verticalPadding 기본값(20pt)이 이미 버튼 컴포넌트에 적용되어 있어,
해당 화면에서는 중복 적용을 피하기 위해 verticalPadding을 제거했습니다.
또한 버튼의 하단 간격은 Figma 디자인 값에 맞춰 .padding(.bottom, 20) 으로 수정했습니다.
  
---

## 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="256" height="472" alt="스크린샷 2025-11-16 오후 5 15 54" src="https://github.com/user-attachments/assets/746b6977-c498-4860-887e-65382ca305dc" />


---

## 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->
<!-- 
예시:
- [ ] UI 정상 동작 확인
- [ ] iPhone 16, iOS 18 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)
-->

- [ ] (내용 작성)

---

## 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->
<!--
예시:
- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다
-->

- (내용 작성)
  
---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
<!--
예시:
- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
-->

- (내용 작성)
