### PR TITLE
Fix: ConqueredButton 위치 조정 및 터치 영역 수정

### DIFF
--- a/DanDan/DanDan/Sources/DesignSystem/Component/Button/ConqueredButton.swift
+++ b/DanDan/DanDan/Sources/DesignSystem/Component/Button/ConqueredButton.swift
@@ -49,7 +49,7 @@ struct ConqueredButton: View {
                     }
                     // 불필요하게 큰 외부 프레임을 제거해 히트 영역을 축소
                     .scaleEffect(isFloating ? 1.18 : 1.0)
-                    .shadow(color: .black.opacity(0.5),
+                    .shadow(color: .black.opacity(0.3),
                             radius: isFloating ? 10 : 6,
                             x: 0, y: isFloating ? 34 : 26)
                     .opacity(buttonOpacity)

--- a/DanDan/DanDan/Sources/Views/Map/SubViews/FullMap/FullMapView.swift
+++ b/DanDan/DanDan/Sources/Views/Map/SubViews/FullMap/FullMapView.swift
@@ -218,7 +218,7 @@ struct FullMapView: UIViewRepresentable {
                 // Conquer buttons
                 ForEach(positioned.filter { $0.needsClaim }) { item in
                     ConqueredButton(zoneId: item.zone.zoneId) { ZoneConquerActionHandler.handleConquer(zoneId: $0) }
-                        .position(x: item.point.x, y: item.point.y - 60)
+                        .position(x: item.point.x - 20, y: item.point.y - 40)
                         .zIndex(Double(item.point.y))
                     }
             }
@@ -359,7 +359,7 @@ struct FullMapView: UIViewRepresentable {
 //                }
                 ForEach(context.coordinator.positioned.filter { $0.needsClaim }) { item in
                     ConqueredButton(zoneId: item.zone.zoneId) { ZoneConquerActionHandler.handleConquer(zoneId: $0) }
-                        .position(x: item.point.x, y: item.point.y - 60)
+                        .position(x: item.point.x - 20, y: item.point.y - 40)
                         .zIndex(Double(item.point.y))
                 }
             }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #278 

---

## 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
<!-- 
예시:
- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시
-->

- Conquered Button의 크기를 조절하여 이전에 누르면 다른 버튼이 사라지는 버그를 수정했습니다.
- 기존에 FullMapView에서 해당 철길숲 위(y값 기준 -100) 100 이상 떨어져있던 위치를 60으로 조정
- 또한 x값 기준 -20으로 배치
- 그림자값 기존 0.5 -> 0.3으로 연하게 수정
  
---

## 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="IMG_1458" src="https://github.com/user-attachments/assets/d8abdd25-677e-4975-a310-cf5e8b914d87" />
<img width="300" alt="IMG_1457" src="https://github.com/user-attachments/assets/4f9995cf-4f44-4a8e-832c-f20de003a14e" />


---

## 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->
<!-- 
예시:
- [ ] UI 정상 동작 확인
- [ ] iPhone 16, iOS 18 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)
-->

- [ ] (내용 작성)

---

## 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->
<!--
예시:
- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다
-->

- (내용 작성)
  
---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
<!--
예시:
- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식
-->

- (내용 작성)
