### PR TITLE
Fix: 마이페이지, 시즌히스토리 뷰 자신의 팀 아이콘 수정

### DIFF
--- a/DanDan/DanDan/Sources/Views/MyPage/SeasonHistory/SubViews/ActiveSeasonCard.swift
+++ b/DanDan/DanDan/Sources/Views/MyPage/SeasonHistory/SubViews/ActiveSeasonCard.swift
@@ -34,7 +34,7 @@ struct ActiveSeasonCard: View {
 
             // TODO: 자신의 현재 팀 아이콘으로 설정
             HStack(spacing: 0) {
-                Image(viewModel.currentTeamName == "blue" ? "train_R_blue" : "train_R_yellow")
+                Image(viewModel.currentTeamName.lowercased() == "blue" ? "train_R_blue" : "train_R_yellow")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 70, height: 70)

--- a/DanDan/DanDan/Sources/Views/MyPage/SubViews/WeeklyActivityCard/WeeklyActivityCard.swift
+++ b/DanDan/DanDan/Sources/Views/MyPage/SubViews/WeeklyActivityCard/WeeklyActivityCard.swift
@@ -13,10 +13,9 @@ struct WeeklyActivityCard: View {
     let weekScore: Int
     let teamRank: Int
     let teamName: String
-    
+
     var body: some View {
         VStack(spacing: 24) {
-            
             // TODO: 컴포넌트화 필요
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
@@ -30,7 +29,7 @@ struct WeeklyActivityCard: View {
 
                 Spacer()
 
-                Image(teamName == "blue" ? "train_L_blue" : "train_L_yellow")
+                Image(teamName.lowercased() == "blue" ? "train_L_blue" : "train_L_yellow")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 55, height: 55)
@@ -78,6 +77,6 @@ struct WeeklyActivityCard: View {
     }
 }
 
-//#Preview {
+// #Preview {
 //    WeeklyActivityCard(viewModel: MyPageViewModel())
-//}
+// }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #279 

---

## 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
<!-- 
예시:
- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시
-->

- 기존에 yellow 팀으로만 매핑되고 있던 오류 수정
- 원인: .lowercased()를 사용하지 않음.
- Blue/Yellow 로 배정 되고 있었음. 하지만 팀 명칭을 blue/yellow 로 하고 있었음.
  
---

## 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300"  alt="IMG_1465" src="https://github.com/user-attachments/assets/3a23c070-32fe-4baa-9311-1b6496adc2e1" />
<img width="300" alt="IMG_1464" src="https://github.com/user-attachments/assets/78de81e4-bb39-4b65-b3a7-47d5be92e237" />


