### PR TITLE
Feat: TrackingView 움직일 수 있게 하기

### DIFF
--- a/DanDan/DanDan/Sources/DesignSystem/Component/TabBarView.swift
+++ b/DanDan/DanDan/Sources/DesignSystem/Component/TabBarView.swift
@@ -18,7 +18,7 @@ struct TabBarView: View {
                 RankingView()
             }
             Tab("지도", systemImage: "map.fill", value: .main){
-                MapToggleView(
+                MapView(
                     conquestStatuses: viewModel.conquestStatuses,
                     teams: viewModel.teams
                 )

--- a/DanDan/DanDan/Sources/Views/Map/MapView.swift
+++ b/DanDan/DanDan/Sources/Views/Map/MapView.swift
@@ -1,5 +1,5 @@
 //
-//  MapToggleView.swift
+//  MapView.swift
 //  DanDan
 //
 //  Created by soyeonsoo on 11/2/25.
@@ -9,7 +9,7 @@ import SwiftUI
 import MapKit
 import CoreLocation
 
-struct MapToggleView: View {
+struct MapView: View {
     @State private var isFullMap = false
     @StateObject private var locationService = LocationService()
     @State private var tracker: ZoneTrackerManager?
@@ -95,10 +95,10 @@ struct MapToggleView: View {
                     isFullMap.toggle()
                 }
             } label: {
-                Image(systemName: "globe.central.south.asia.fill")
-                    .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(isFullMap ? .primaryGreen : .steelBlack)
-                    .frame(width: 56, height: 56)
+                Image(systemName: isFullMap ? "arrow.down.left.and.arrow.up.right.rectangle.fill" : "arrow.down.right.and.arrow.up.left.rectangle.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(.steelBlack)
+                    .frame(width: 44, height: 44)
             }
             .buttonStyle(.plain)
             .background(.ultraThinMaterial, in: Circle())
@@ -109,8 +109,7 @@ struct MapToggleView: View {
             .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
             .padding(.trailing, 20)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-            .padding(.top, 158)
+            .padding(.top, 150)
         }
     }
 }
-

--- a/DanDan/DanDan/Sources/Views/Map/SubViews/TrackingMap/Component/TrackingButton.swift
+++ b/DanDan/DanDan/Sources/Views/Map/SubViews/TrackingMap/Component/TrackingButton.swift
@@ -1,0 +1,33 @@
+//
+//  TrackingButton.swift
+//  DanDan
+//
+//  Created by soyeonsoo on 11/18/25.
+//
+
+import SwiftUI
+
+struct TrackingButton: View {
+    @Binding var isTracking: Bool
+    var restoreTracking: () -> Void
+    
+    var body: some View {
+        Button {
+            restoreTracking()
+        } label: {
+            Image(systemName: "location.fill")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(isTracking ? .primaryGreen : .steelBlack)
+                .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.plain)
+        .background(.ultraThinMaterial, in: Circle())
+        .overlay(
+            Circle()
+                .strokeBorder(.white.opacity(0.4), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
+        .padding(.trailing, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+    }
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #272 

---

## 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
<!-- 
예시:
- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시
-->

- 스크롤이 가능하게 했어요.
- 스크롤 후 다시 트래킹 모드로 돌아오는 버튼을 만들었어요.
- 스크롤하면 버튼 색이 꺼지고, 트래킹 모드일 때 다시 켜집니다. (켜져있는 게 디폴트)
- 지구 버튼 아이콘 모양을 변경했어요.
  
---

## 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


https://github.com/user-attachments/assets/bd7b7508-e2c4-4070-84ac-87dbc488e65b

_화면 돌아가는 건 트래킹 중인 걸 확인하려고 폰을 돌린 것임_

---

## 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->
<!--
예시:
- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다
-->

- 지금 TrackingMapView는 SwfitUI를 ZStack으로 올리고 있고 FullMapView는 overlay로 올리고 있어요.
그래서 레이아웃을 맞춰도 차이가 납니다. TrackingMapView를 기준으로 만지니 FullMapView 레이아웃이 이상해요.
방식을 하나로 통일해야할 것 같습니다. 
결론: TrackingView 처럼 FullMapView도 ZStack으로 바꾸려고 하는데 괜찮나요 세나양? @hiseyeon 

- 우선 기능을 구현했어요. 위시의 의도대로라면 저게 탭바로 들어가는 게 맞지만? 여기에 두고 싶은데 한 번 봐바요 @wish627 
  - 이대로 두고 싶은 이유
    - 움직이는 탭바 하려면 26버전 따로, 이전 버전 따로 만들어야 됨
    - '탭'의 역할이 아님. 화면이 바뀌는 게 아니라 지금 보고 있는 지도 화면의 카메라 상태를 바꾸는 액션임.
    - 애플 지도, 카카오맵, 네이버 지도 모두 현위치 버튼이 플로팅 버튼으로 있음.
    - 맵 토글 버튼 아래 있는 게 안 이상해 보임. 토글 버튼도 버튼이라서.
   삥삥 그래도 바꾸라면 바꿀거예여