### PR TITLE
Feature: TrackingView - Conquered Button 배치 및 점수 연동

### DIFF
--- a/DanDan/DanDan/Sources/DesignSystem/Component/Button/ConqueredButton.swift
+++ b/DanDan/DanDan/Sources/DesignSystem/Component/Button/ConqueredButton.swift
@@ -26,6 +26,9 @@ struct ConqueredButton: View {
     }
     
     var body: some View {
+        // 버튼/로띠가 차지할 고정 영역 (부모 HStack 기준 위치가 변하지 않도록)
+        let containerSize = CGSize(width: 120, height: 90)
+
         ZStack {
             if isVisible {
                 Button {
@@ -47,7 +50,7 @@ struct ConqueredButton: View {
                             .frame(width: 80, height: 56)
                             .accessibilityLabel(Text("구역 보상 받기"))
                     }
-                    // 불필요하게 큰 외부 프레임을 제거해 히트 영역을 축소
+                    .frame(width: containerSize.width, height: containerSize.height)
                     .scaleEffect(isFloating ? 1.18 : 1.0)
                     .shadow(color: .black.opacity(0.3),
                             radius: isFloating ? 10 : 6,
@@ -60,12 +63,14 @@ struct ConqueredButton: View {
                 .buttonStyle(.plain)
                 .zIndex(1)
             }
-            
+
             if showScoreLottie {
                 LottieOnceView(name: scoreLottieName)
-                    .frame(width: 100, height: 80)
-                    .zIndex(0)
+                    .frame(width: containerSize.width, height: containerSize.height)
+                    .allowsHitTesting(false)
+                    .zIndex(2)
             }
         }
+        .frame(width: containerSize.width, height: containerSize.height)
     }
 }

--- a/DanDan/DanDan/Sources/Utility/Managers/SignsManager.swift
+++ b/DanDan/DanDan/Sources/Utility/Managers/SignsManager.swift
@@ -25,7 +25,7 @@ final class SignsManager {
 		mapView: MKMapView,
 		zones: [Zone],
 		validRange: ClosedRange<Int> = 1...15,
-		threshold: CLLocationDistance = 120
+		threshold: CLLocationDistance = 200
 	) {
 		self.mapView = mapView
 		self.zones = zones

--- a/DanDan/DanDan/Sources/Utility/Managers/StatusManager.swift
+++ b/DanDan/DanDan/Sources/Utility/Managers/StatusManager.swift
@@ -68,6 +68,13 @@ class StatusManager: ObservableObject {
         userStatus.userDailyScore += 1
         userStatus.userWeekScore += 1
     }
+    
+    /// 사용자의 일일/주간 점수를 지정된 수치만큼 증가시킵니다.
+    func incrementDailyScore(by amount: Int) {
+        guard amount > 0 else { return }
+        userStatus.userDailyScore += amount
+        userStatus.userWeekScore += amount
+    }
 
     /// 사용자가 오늘 해당 구간을 지나갔다면, 체크 상태로 저장합니다.
     /// - Parameters:

--- a/DanDan/DanDan/Sources/Views/Map/Component/ZoneStation/Sign/ZoneSigns.swift
+++ b/DanDan/DanDan/Sources/Views/Map/Component/ZoneStation/Sign/ZoneSigns.swift
@@ -9,15 +9,35 @@ import SwiftUI
 
 struct ZoneSigns: View {
 	let zoneId: Int
+	@State private var showSheet = false
+	@StateObject private var viewModel = MapScreenViewModel()
 	
 	var body: some View {
-		Image("sign\(zoneId)")
-			.resizable()
-			.scaledToFit()
-			.frame(width: 120, height: 120)
+		Button {
+			showSheet = true
+		} label: {
+			Image("sign\(zoneId)")
+				.resizable()
+				.scaledToFit()
+				.frame(width: 120, height: 120)
+		}
+		.buttonStyle(.plain)
+		.sheet(isPresented: $showSheet) {
+			if let z = zones.first(where: { $0.zoneId == zoneId }) {
+				ZoneInfoView(
+					zone: z,
+					teamScores: viewModel.zoneTeamScores[z.zoneId] ?? []
+				)
+				.task {
+					await viewModel.loadZoneTeamScores(for: z.zoneId)
+				}
+			} else {
+				EmptyView()
+			}
+		}
 	}
 }
 
-//#Preview {
-//	ZoneSigns(zoneId: 1)
-//}
+#Preview {
+	ZoneSigns(zoneId: 1)
+}

--- a/DanDan/DanDan/Sources/Views/Map/SubViews/FullMap/FullMapView.swift
+++ b/DanDan/DanDan/Sources/Views/Map/SubViews/FullMap/FullMapView.swift
@@ -628,59 +628,59 @@ struct FullMapScreen: View {
                 viewModel.startDDayTimer(period: period)
             }
         }
-        .overlay(alignment: .bottomLeading) {
-#if DEBUG
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(1...15, id: \.self) { id in
-                        Button(action: {
-                            // 로컬 먼저 반영 (개인 지도 즉시 표시)
-                            StatusManager.shared.setZoneChecked(
-                                zoneId: id,
-                                checked: true
-                            )
-                            effectiveToken = UUID()
-                            // 서버 전송은 후행, 실패해도 로컬 상태 유지
-                            ZoneCheckedService.shared.postChecked(
-                                zoneId: id
-                            ) { ok in
-                                if !ok {
-                                    print(
-                                        "[DEBUG] 서버 전송 실패: zoneId=\(id) — 로컬 상태는 유지"
-                                    )
-                                }
-                            }
-                        }) {
-                            Text("#\(id)")
-                                .font(.PR.caption2)
-                                .foregroundColor(.white)
-                                .padding(.vertical, 6)
-                                .padding(.horizontal, 10)
-                                .background(Color.black.opacity(0.6))
-                                .clipShape(Capsule())
-                        }
-                    }
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-            }
-            .background(
-                Color.black.opacity(0.15)
-                    .blur(radius: 2)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .padding(.leading, 16)
-            .padding(.bottom, 120)
-            .onAppear {
-                // 최초 진입 시, 부모에서 전달받은 토큰을 채택
-                effectiveToken = refreshToken
-            }
-            .onChange(of: refreshToken) { newValue in
-                // 부모 갱신 토큰 변화도 반영
-                effectiveToken = newValue
-            }
-#endif
-        }
+//        .overlay(alignment: .bottomLeading) {
+//#if DEBUG
+//            ScrollView(.horizontal, showsIndicators: false) {
+//                HStack(spacing: 8) {
+//                    ForEach(1...15, id: \.self) { id in
+//                        Button(action: {
+//                            // 로컬 먼저 반영 (개인 지도 즉시 표시)
+//                            StatusManager.shared.setZoneChecked(
+//                                zoneId: id,
+//                                checked: true
+//                            )
+//                            effectiveToken = UUID()
+//                            // 서버 전송은 후행, 실패해도 로컬 상태 유지
+//                            ZoneCheckedService.shared.postChecked(
+//                                zoneId: id
+//                            ) { ok in
+//                                if !ok {
+//                                    print(
+//                                        "[DEBUG] 서버 전송 실패: zoneId=\(id) — 로컬 상태는 유지"
+//                                    )
+//                                }
+//                            }
+//                        }) {
+//                            Text("#\(id)")
+//                                .font(.PR.caption2)
+//                                .foregroundColor(.white)
+//                                .padding(.vertical, 6)
+//                                .padding(.horizontal, 10)
+//                                .background(Color.black.opacity(0.6))
+//                                .clipShape(Capsule())
+//                        }
+//                    }
+//                }
+//                .padding(.horizontal, 12)
+//                .padding(.vertical, 10)
+//            }
+//            .background(
+//                Color.black.opacity(0.15)
+//                    .blur(radius: 2)
+//            )
+//            .clipShape(RoundedRectangle(cornerRadius: 12))
+//            .padding(.leading, 16)
+//            .padding(.bottom, 120)
+//            .onAppear {
+//                // 최초 진입 시, 부모에서 전달받은 토큰을 채택
+//                effectiveToken = refreshToken
+//            }
+//            .onChange(of: refreshToken) { newValue in
+//                // 부모 갱신 토큰 변화도 반영
+//                effectiveToken = newValue
+//            }
+//#endif
+//        }
 //        .overlay(alignment: .topTrailing) {
         // #if DEBUG
 //            ZoneDebugOverlay()

--- a/DanDan/DanDan/Sources/Views/Map/SubViews/FullMap/FullMapView.swift
+++ b/DanDan/DanDan/Sources/Views/Map/SubViews/FullMap/FullMapView.swift
@@ -328,12 +328,17 @@ struct FullMapView: UIViewRepresentable {
         private var highlightedInner: HighlightedPolyline?
         private var highlightedFill: HighlightedPolygon?
         
+        // 선택 가능한 구역(1~15)으로 제한
+        private var selectableZones: [Zone] {
+            zones.filter { (1...15).contains($0.zoneId) }
+        }
+        
         private func nearestZoneId(to coord: CLLocationCoordinate2D) -> Int? {
-            guard !zones.isEmpty else { return nil }
+            guard !selectableZones.isEmpty else { return nil }
             var bestId: Int?
             var bestDistance: CLLocationDistance = .greatestFiniteMagnitude
             let target = CLLocation(latitude: coord.latitude, longitude: coord.longitude)
-            for z in zones {
+            for z in selectableZones {
                 let c = parent.centroid(of: z.coordinates)
                 let d = target.distance(from: CLLocation(latitude: c.latitude, longitude: c.longitude))
                 if d < bestDistance {
@@ -623,59 +628,59 @@ struct FullMapScreen: View {
                 viewModel.startDDayTimer(period: period)
             }
         }
-//        .overlay(alignment: .bottomLeading) {
-//#if DEBUG
-//            ScrollView(.horizontal, showsIndicators: false) {
-//                HStack(spacing: 8) {
-//                    ForEach(1...15, id: \.self) { id in
-//                        Button(action: {
-//                            // 로컬 먼저 반영 (개인 지도 즉시 표시)
-//                            StatusManager.shared.setZoneChecked(
-//                                zoneId: id,
-//                                checked: true
-//                            )
-//                            effectiveToken = UUID()
-//                            // 서버 전송은 후행, 실패해도 로컬 상태 유지
-//                            ZoneCheckedService.shared.postChecked(
-//                                zoneId: id
-//                            ) { ok in
-//                                if !ok {
-//                                    print(
-//                                        "[DEBUG] 서버 전송 실패: zoneId=\(id) — 로컬 상태는 유지"
-//                                    )
-//                                }
-//                            }
-//                        }) {
-//                            Text("#\(id)")
-//                                .font(.PR.caption2)
-//                                .foregroundColor(.white)
-//                                .padding(.vertical, 6)
-//                                .padding(.horizontal, 10)
-//                                .background(Color.black.opacity(0.6))
-//                                .clipShape(Capsule())
-//                        }
-//                    }
-//                }
-//                .padding(.horizontal, 12)
-//                .padding(.vertical, 10)
-//            }
-//            .background(
-//                Color.black.opacity(0.15)
-//                    .blur(radius: 2)
-//            )
-//            .clipShape(RoundedRectangle(cornerRadius: 12))
-//            .padding(.leading, 16)
-//            .padding(.bottom, 120)
-//            .onAppear {
-//                // 최초 진입 시, 부모에서 전달받은 토큰을 채택
-//                effectiveToken = refreshToken
-//            }
-//            .onChange(of: refreshToken) { newValue in
-//                // 부모 갱신 토큰 변화도 반영
-//                effectiveToken = newValue
-//            }
-//#endif
-//        }
+        .overlay(alignment: .bottomLeading) {
+#if DEBUG
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(1...15, id: \.self) { id in
+                        Button(action: {
+                            // 로컬 먼저 반영 (개인 지도 즉시 표시)
+                            StatusManager.shared.setZoneChecked(
+                                zoneId: id,
+                                checked: true
+                            )
+                            effectiveToken = UUID()
+                            // 서버 전송은 후행, 실패해도 로컬 상태 유지
+                            ZoneCheckedService.shared.postChecked(
+                                zoneId: id
+                            ) { ok in
+                                if !ok {
+                                    print(
+                                        "[DEBUG] 서버 전송 실패: zoneId=\(id) — 로컬 상태는 유지"
+                                    )
+                                }
+                            }
+                        }) {
+                            Text("#\(id)")
+                                .font(.PR.caption2)
+                                .foregroundColor(.white)
+                                .padding(.vertical, 6)
+                                .padding(.horizontal, 10)
+                                .background(Color.black.opacity(0.6))
+                                .clipShape(Capsule())
+                        }
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+            }
+            .background(
+                Color.black.opacity(0.15)
+                    .blur(radius: 2)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.leading, 16)
+            .padding(.bottom, 120)
+            .onAppear {
+                // 최초 진입 시, 부모에서 전달받은 토큰을 채택
+                effectiveToken = refreshToken
+            }
+            .onChange(of: refreshToken) { newValue in
+                // 부모 갱신 토큰 변화도 반영
+                effectiveToken = newValue
+            }
+#endif
+        }
 //        .overlay(alignment: .topTrailing) {
         // #if DEBUG
 //            ZoneDebugOverlay()

--- a/DanDan/DanDan/Sources/Views/Map/SubViews/TrackingMap/TrackingMapView.swift
+++ b/DanDan/DanDan/Sources/Views/Map/SubViews/TrackingMap/TrackingMapView.swift
@@ -204,7 +204,7 @@ struct TrackingMapView: UIViewRepresentable {
             mapView: map,
             zones: zones,
             validRange: 1 ... 15,
-            threshold: 120
+            threshold: 200
         )
         
         // 선과 정류소 버튼 표시

--- a/DanDan/DanDan/Sources/Views/Map/SubViews/TrackingMap/TrackingMapView.swift
+++ b/DanDan/DanDan/Sources/Views/Map/SubViews/TrackingMap/TrackingMapView.swift
@@ -107,25 +107,25 @@ struct TrackingMapView: UIViewRepresentable {
         
         /// 오버레이(폴리라인) 렌더러 - 구역별 색/굵기 등 스타일 지정
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-            if let circle = overlay as? MKCircle {
-                let r = MKCircleRenderer(overlay: circle)
-#if DEBUG
-                let title = circle.title ?? ""
-                // start: 빨강, end: 파랑. in은 실선, out은 점선
-                if title.contains("debug-circle-start") {
-                    r.strokeColor = UIColor.systemRed.withAlphaComponent(0.9)
-                    r.fillColor = UIColor.systemRed.withAlphaComponent(0.08)
-                } else {
-                    r.strokeColor = UIColor.systemBlue.withAlphaComponent(0.9)
-                    r.fillColor = UIColor.systemBlue.withAlphaComponent(0.08)
-                }
-                r.lineWidth = 2
-                if title.hasSuffix("-out") {
-                    r.lineDashPattern = [6, 6]
-                }
-#endif
-                return r
-            }
+//            if let circle = overlay as? MKCircle {
+//                let r = MKCircleRenderer(overlay: circle)
+//#if DEBUG
+//                let title = circle.title ?? ""
+//                // start: 빨강, end: 파랑. in은 실선, out은 점선
+//                if title.contains("debug-circle-start") {
+//                    r.strokeColor = UIColor.systemRed.withAlphaComponent(0.9)
+//                    r.fillColor = UIColor.systemRed.withAlphaComponent(0.08)
+//                } else {
+//                    r.strokeColor = UIColor.systemBlue.withAlphaComponent(0.9)
+//                    r.fillColor = UIColor.systemBlue.withAlphaComponent(0.08)
+//                }
+//                r.lineWidth = 2
+//                if title.hasSuffix("-out") {
+//                    r.lineDashPattern = [6, 6]
+//                }
+//#endif
+//                return r
+//            }
             if let line = overlay as? ColoredPolyline {
                 let renderer = MKPolylineRenderer(overlay: line)
                 renderer.strokeColor = strokeProvider.stroke(for: line.zoneId, isOutline: line.isOutline)
@@ -151,46 +151,14 @@ struct TrackingMapView: UIViewRepresentable {
                 
                 let swiftUIView = ZoneSigns(zoneId: ann.destinationZoneId)
                 view.setSwiftUIView(swiftUIView)
-                view.contentSize = CGSize(width: 80, height: 80)
+                view.contentSize = CGSize(width: 120, height: 120)
                 view.centerOffset = CGPoint(x: 0, y: -60)
                 view.canShowCallout = false
                 return view
             }
-            guard let ann = annotation as? StationAnnotation else { return nil }
-            
-            let id = "station-hosting"
-            let view: HostingAnnotationView
-            if let reused = mapView.dequeueReusableAnnotationView(withIdentifier: id) as? HostingAnnotationView {
-                view = reused
-                view.annotation = ann
-            } else {
-                view = HostingAnnotationView(annotation: ann, reuseIdentifier: id)
-            }
-            
-            // 정복 조건(오늘 체크했고, 보상 미수령) 판단 후 뷰 구성
-            let isChecked = StatusManager.shared.userStatus.zoneCheckedStatus[ann.zone.zoneId] == true
-            let isClaimed = StatusManager.shared.isRewardClaimed(zoneId: ann.zone.zoneId)
-            
-            let swiftUIView = ZStack {
-                // TODO: 제거 예정
-                //                ZoneStation(
-                //                    zone: ann.zone,
-                //                    statusesForZone: ann.statusesForZone,
-                //                    zoneTeamScores: viewModel?.zoneTeamScores ?? [:],
-                //                    loadZoneTeamScores: { zoneId in
-                //                        Task {await self.viewModel!.loadZoneTeamScores(for: zoneId) }
-                //                    }
-                //                )
-                if isChecked && !isClaimed {
-                    ConqueredButton(zoneId: ann.zone.zoneId) { ZoneConquerActionHandler.handleConquer(zoneId: $0) }
-                        .offset(y: -120)
-                }
-            }
-            view.setSwiftUIView(swiftUIView)
-            view.contentSize = CGSize(width: 160, height: 190)
-            view.centerOffset = CGPoint(x: 10, y: -36)
-            view.canShowCallout = false
-            return view
+            // 트래킹 지도에서는 정복 버튼을 지도 어노테이션으로 표시하지 않음
+            if annotation is StationAnnotation { return nil }
+            return nil
         }
     }
     
@@ -288,26 +256,6 @@ struct TrackingMapView: UIViewRepresentable {
         // 렌더러 색 갱신 + 정류소 데이터 최신화
         DispatchQueue.main.async {
             MapOverlayRefresher.refreshColors(on: uiView, with: context.coordinator.strokeProvider)
-            
-            for annotation in uiView.annotations {
-                guard let ann = annotation as? StationAnnotation,
-                      let view = uiView.view(for: ann) as? HostingAnnotationView else { continue }
-                
-                let isChecked = StatusManager.shared.userStatus.zoneCheckedStatus[ann.zone.zoneId] == true
-                let isClaimed = StatusManager.shared.isRewardClaimed(zoneId: ann.zone.zoneId)
-                
-                let swiftUIView = ZStack {
-                    if isChecked && !isClaimed {
-                        ConqueredButton(zoneId: ann.zone.zoneId) { ZoneConquerActionHandler.handleConquer(zoneId: $0) }
-                            .offset(y: -120)
-                    }
-                }
-                
-                view.setSwiftUIView(swiftUIView)
-                view.contentSize = CGSize(width: 160, height: 190)
-                view.centerOffset = CGPoint(x: 10, y: -36)
-                view.canShowCallout = false
-            }
         }
     }
 }
@@ -316,6 +264,7 @@ struct TrackingMapScreen: View {
     @StateObject private var viewModel = MapScreenViewModel()
     @State private var onRestoreTracking = false
     @State private var isTracking = true  // 버튼 색상 전환용 상태
+    @ObservedObject private var status = StatusManager.shared
     
     let conquestStatuses: [ZoneConquestStatus]
     let teams: [Team]
@@ -367,6 +316,30 @@ struct TrackingMapScreen: View {
                 .padding(.vertical, 58)
                 .padding(.horizontal, 20)
                 
+                // ScoreBoard 아래에 고정되는 정복 보상 버튼(집계)
+                let pendingZoneIds: [Int] = zones
+                    .map(\.zoneId)
+                    .filter { id in
+                        let checked = status.userStatus.zoneCheckedStatus[id] == true
+                        let claimed = StatusManager.shared.isRewardClaimed(zoneId: id)
+                        return checked && !claimed
+                    }
+                
+                if !pendingZoneIds.isEmpty {
+                    HStack(spacing: 10) {
+                        ConqueredButton(zoneId: pendingZoneIds.first ?? 0) { _ in
+                            ZoneConquerActionHandler.handleConquer(zoneIds: pendingZoneIds)
+                        }
+                        if pendingZoneIds.count >= 2 {
+                            Text("x\(pendingZoneIds.count)")
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(.white)
+                                .shadow(color: .black.opacity(0.35), radius: 4, x: 0, y: 2)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                }
+                
                 TrackingButton(
                     isTracking: $isTracking,
                     restoreTracking: {
@@ -378,6 +351,10 @@ struct TrackingMapScreen: View {
         .task {
             await viewModel.loadMapInfo()
             viewModel.startDDayTimer(period: period)
+        }
+        // 점수/상태 갱신 알림 수신하여 상단 점수 동기화
+        .onReceive(NotificationCenter.default.publisher(for: ZoneConquerActionHandler.didUpdateScoreNotification)) { _ in
+            viewModel.userDailyScore = StatusManager.shared.userStatus.userDailyScore
         }
         //        .overlay(alignment: .topTrailing) {
         //#if DEBUG


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (타입 + 이슈 번호 + 작업 요약)
예시: Feature: 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #191
- Closes #192 
- Closes #282 

---

## 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
<!-- 
예시:
- 새로운 컴포넌트 `XxxView` 추가
- API 연동 로직 리팩토링
- 버그 수정: 홈 화면 진입 시 크래시
-->

**TrackingMapView**
- 어노테이션 기반 정복 버튼 제거
- 상단 UI에 정복 버튼 고정 배치 + 배지 + 디버그 오버레이
- 점수 갱신 알림 수신하여 viewModel.userDailyScore 즉시 업데이트

**MapManager**
- ZoneConquerActionHandler.handleConquer(zoneIds:) 추가(일괄 정복/점수 가산/알림 1회)

**StatusManager**
- incrementDailyScore(by:) 추가

**ZoneSigns**
- 이미지 -> Button 교체
- ZoneSigns 탭 했을 경우 ZoneInfoView(sheet) 보여줌

---

## 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


https://github.com/user-attachments/assets/c9fe75cb-ad33-4b01-93ce-6bbdf3865553


https://github.com/user-attachments/assets/efcbc109-aa97-4449-b29a-1fb11236876a

